### PR TITLE
fix(build webpack -p and bundle.js into production)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "webpack -p",
+    "build": "webpack -p & git add -f public/bundle.js public/bundle.js.map",
     "build-client": "webpack",
     "build-client-watch": "webpack -w",
     "deploy": "script/deploy",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "build": "webpack -p",
     "build-client": "webpack",
     "build-client-watch": "webpack -w",
     "deploy": "script/deploy",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "webpack -p & git add -f public/bundle.js public/bundle.js.map",
+    "build": "webpack -p",
     "build-client": "webpack",
     "build-client-watch": "webpack -w",
     "deploy": "script/deploy",


### PR DESCRIPTION
Adds a build script putting webpack into production and forcing bundle into the public folder on deployment.

This is a test and may need to be refined.